### PR TITLE
add content for purpose of devrel guide page

### DIFF
--- a/purpose-of-this-guide.mdx
+++ b/purpose-of-this-guide.mdx
@@ -1,0 +1,21 @@
+---
+title: Purpose of this Guide
+---
+
+The purpose of this guide is to serve as a **collaborative, evolving resource** 
+that captures the principles, practices, and experiences of Developer Relations (DevRel) professionals. 
+Created by the **DXMentorship community**, it is designed to support both aspiring and seasoned
+DevRel professionals by offering practical and first hand insights, frameworks, and strategies grounded in
+real world context.
+
+This guide aims to:
+
+- **Demystify DevRel** by clearly defining its scope, goals, and impact within tech organizations.
+- **Standardize knowledge** across the DevRel space, helping newcomers onboard faster and practitioners scale their efforts more effectively.
+- **Highlight best practices** in areas such as community building, developer experience (DX), content creation, product advocacy, feedback loops, and more.
+- **Encourage diverse contributions**, ensuring that different voices and perspectives are reflected, especially from underrepresented regions or industries.
+- **Provide a portfolio-worthy project** for contributors—showcasing collaborative work that blends writing, research, and thought leadership in Developer Relations.
+
+By documenting what works (and what doesn’t), this guide becomes a valuable tool not only for individual learning but also for teams, hiring managers, and organizations looking to strengthen their developer-facing efforts.
+
+


### PR DESCRIPTION
**PR Summary:**

* **feat:** Add detailed content to the "Purpose of this Guide" page in the DevRel Guide documentation.
* Elaborates on the guide’s goals, target audience, and value for contributors and the broader tech ecosystem.
* Emphasizes collaboration, real-world application, and portfolio-building for community members.
*

This PR seeks to resolve issue #12 
