### PR TITLE
feat: added all sections on community building

### DIFF
--- a/content-and-knowledge-sharing.mdx
+++ b/content-and-knowledge-sharing.mdx
@@ -1,0 +1,84 @@
+---
+title: Content and Knowledge Sharing
+description: "Learn how to turn your community into a hub for ideas, tutorials, and collaboration."
+---
+
+# Content and Knowledge Sharing
+
+One of the most powerful ways to grow and sustain your developer community is by turning it into a place where knowledge flows freely, from you and from your members.
+
+When people share what they know, they feel ownership. And when others learn from that, they stay.
+
+---
+
+## 🧠 Why It Matters
+
+Developer communities thrive when members:
+- Share what they’re building or learning
+- Ask and answer questions
+- Write guides, tutorials, or best practices
+- Contribute to shared docs or demos
+
+Encouraging this creates a cycle of learning, recognition, and engagement, a win-win for your product and your people.
+
+---
+
+## ✍️ What Members Can Create
+
+Guide members on what kinds of content they can contribute:
+- **Project showcases**: Demos, case studies, portfolio projects
+- **Tutorials**: Walkthroughs on how they used your product or tool
+- **Tips and tricks**: Snippets, productivity hacks, or integrations
+- **Blog posts**: Technical deep-dives or personal journeys
+- **Videos/live streams**: Demos, reviews, or workshop recordings
+- **Documentation updates**: Fixes, examples, or new sections
+
+You can also offer templates or example formats to help them get started.
+
+---
+
+## 🚀 How to Encourage Sharing
+
+Create the right environment and incentives:
+- Start with a **#showcase** or **#content-sharing** channel in your community
+- Run a **monthly spotlight** for top contributors
+- Launch a **content challenge** (e.g., “Write a guide using X”)
+- Provide **recognition** (shoutouts, swag, contributor badges)
+- Make it easy to **submit content** — use a form or GitHub link
+
+---
+
+## 💡 Internal Content Strategy
+
+In parallel, maintain a rhythm of consistent content from your team:
+- **Dev blogs**: Product updates, behind-the-scenes, tutorials
+- **FAQs**: Summarized insights from community questions
+- **Release notes**: What’s new and how to use it
+- **Live sessions**: AMAs, workshops, demos
+
+This builds momentum and gives members examples to follow.
+
+---
+
+## 🔄 Surface and Reshare Community Contributions
+
+Don’t let good content go unseen. Reshare it across:
+- Your docs or help center (with credit)
+- Twitter/X, LinkedIn, or newsletters
+- Onboarding flows for new users
+- Events or workshops (“This tutorial was written by our community member...”)
+
+This shows you value contributions — and encourages more of them.
+
+---
+
+## ✅ Keep It Sustainable
+
+As you grow:
+- Create a **content submission process** (e.g., GitHub repo, Airtable, form)
+- Offer **review support** or feedback before publishing
+- Build a **recognition system** (badges, tiers, contributor pages)
+
+---
+
+**Content and knowledge sharing isn't just a nice-to-have — it's how your community teaches, learns, and grows together.** Make it easy, celebrate it often, and watch your community come alive.

--- a/docs.json
+++ b/docs.json
@@ -48,9 +48,9 @@
           {
             "group": "Community Building",
             "pages": [
-              "events-and-meetups",
               "online-community-management",
-              "onboarding-retention-strategies"
+              "events-and-meetups",
+              "content-and-knowledge-sharing"
             ]
           },
           {

--- a/events-and-meetups.mdx
+++ b/events-and-meetups.mdx
@@ -1,1 +1,123 @@
-Event are places we meet
+---
+title: Events and Meetups
+description: "Learn how to plan and run impactful developer events that drive connection, visibility, and long-term engagement."
+---
+
+# Events and Meetups
+
+Events are the heartbeat of any thriving developer community. They are the moments where real connection happens, where usernames become people, and your product or mission comes to life in a shared space.
+
+Whether virtual, in-person, or hybrid, events are essential to driving engagement, trust, and momentum.
+
+---
+
+## 🎯 Why Events Matter
+
+For developer communities, **events aren't an add-on they’re foundational.**
+
+They:
+- Create *face time* in a remote-first world, opening doors for collaboration, mentorship, and real friendships
+- Allow developers to experience your product *in context*, through live demos, hands-on workshops, and real-world use cases
+- Build *emotional connection*, when members attend something together, they’re more likely to stay engaged afterward
+- Offer a platform for *community voice*, letting members contribute talks, host sessions, and share their wins
+- Provide a high-signal moment for *feedback* and *user research*
+
+Done right, events can become propellers for growth, loyalty, and content.
+
+---
+
+## 🧩 Types of Events to Run
+
+Start with formats that match your current goals and team capacity. You can evolve over time.
+
+### 🖥️ Virtual Events
+Low barrier to entry, high flexibility:
+- **Community Calls** — casual syncs to share updates, wins, or roadmap highlights
+- **AMAs** — “Ask Me Anything” sessions with engineers, PMs, or founders
+- **Product Demos** — new feature walkthroughs or integrations
+- **Workshops** — guided tutorials to help users go from zero to productive
+- **Hackathons** — multi-day challenges to build, learn, and show off
+
+### 📍 In-Person Events
+Stronger relationships, deeper impact:
+- **Local Meetups** — informal gatherings in dev hubs, workspaces or cities
+- **Campus/Bootcamp Visits** — connect with student developers early
+- **Roadshows** — tour multiple cities to reach new dev clusters
+- **Developer Days or Summits** — single-day branded events with talks, panels, and community booths
+- **Partner or Community-led Chapters** — empower users to host under your banner
+
+### 🧪 Hybrid Events
+Flexible for global audiences:
+- Stream in-person events for remote members
+- Use digital platforms (e.g., Hopin, Zoom, Discord) for interaction
+- Combine online onboarding with local watch parties or demo nights
+
+---
+
+## 🛠️ Planning Your Event
+
+Every great event is built with intention. Use this framework to stay on track:
+
+### 1. **Set Clear Intentions**
+Before you plan anything, ask:
+- Who is this for? (New users? Power users? Dev advocates?)
+- What do we want them to learn, do, or feel?
+- What does success look like? (e.g., N registrations, % return rate, demo signups)
+
+### 2. **Promotion and Outreach**
+- Start promotion **at least a month** ahead of time
+- Use your strongest channels: Discord, X (Twitter), newsletters, community forums
+- Collaborate with partners or speakers to cross-promote
+- Make sign-up frictionless (use a tool like Luma, Lu.ma, Bevy, or Calendly)
+
+### 3. **Experience Design**
+- Choose the right time zone(s) and duration (shorter is usually better)
+- Create a run-of-show or agenda with time buffers
+- Appoint an MC or host to guide the flow
+- Open with intros, icebreakers, or community shoutouts
+- Ensure there’s room for Q&A or unstructured conversation
+
+### 4. **Post-Event Follow-Up**
+Events don’t end when the call drops:
+- Share recordings and resources
+- Thank attendees and speakers personally
+- Collect feedback via a short form
+- Highlight key takeaways on socials, blogs, or your docs
+- Use momentum to plug in a “what’s next?” (e.g., community call, upcoming launch, contributor program)
+
+---
+
+## 🧠 Tips for Better Engagement
+
+- Use breakout rooms or open-mic moments to increase connection
+- Include live polls, chat prompts, or dev trivia for fun
+- Encourage members to “co-own” the stage — share demos, host lightning talks, or panel moderate
+- Offer live support channels during workshops or hackathons
+- Create hashtags or event-specific threads to capture buzz
+
+---
+
+## 🚀 Scaling Events with Your Community
+
+As your community grows:
+- Build a **speaker roster** of repeat contributors
+- Start a **community-led event series** (e.g., “X Devs Build” or “Show & Ship”)
+- Offer **event toolkits**: slides, swag, templates for local hosts
+- Use a **calendar** or dashboard to track and share upcoming events
+- Reward hosts and contributors with swag, perks, or recognition
+
+---
+
+## 💡 Bonus: Event Ideas to Try
+
+Looking to spice things up? Try these formats:
+- **“Ship It” Showcases** — monthly demo days of community projects
+- **Speed Networking** — breakout rooms to connect new members
+- **Build Along Fridays** — casual coworking or building sessions
+- **“Office Hours IRL”** — in-person drop-ins in key cities
+- **Fail Night** — honest stories of what didn’t work (always a hit!)
+
+---
+
+Events and meetups turn your developer community from a passive audience into a living, breathing movement. Don’t worry about being perfect, just be consistent, listen well, and build together.
+

--- a/online-community-management.mdx
+++ b/online-community-management.mdx
@@ -1,0 +1,118 @@
+---
+sidebar_position: 1
+title: Community Building and Engagement
+description: "Learn how to build and grow an active developer community."
+---
+
+# Community Building and Engagement
+
+A successful developer community is more than just numbers, it’s about people who feel welcome, supported, and excited to be part of something meaningful.
+
+This guide covers simple steps to help you **build**, **engage**, and **grow** your community from the ground up. Whether you're starting a new community or improving an existing one, these tips will help you get there.
+
+---
+
+## 🎯 Start with a Clear Purpose
+
+Before building anything, define what your community is all about:
+
+- **Why does this community exist?**  
+  What value will members get by joining?
+
+- **Who is it for?**  
+  Be specific — is it for frontend developers, beginners, open-source contributors, or another group?
+
+- **What does success look like?**  
+  Are you aiming for active discussions, support, content contributions, or something else?
+
+These answers will help you stay focused and attract the right people.
+
+---
+
+## 📣 Choose the Right Platforms
+
+Pick channels based on where your audience already hangs out. Some common options include:
+
+- **Discord or Slack**  
+  Great for live chats, support channels, and casual hangouts.
+
+- **GitHub Discussions**  
+  Perfect for communities around open-source tools or libraries.
+
+- **Forums or Reddit**  
+  Good for searchable, longer-form Q&A and discussions.
+
+- **Social media (X, LinkedIn, YouTube)**  
+  Useful for announcements, updates, and reaching new audiences.
+
+Start small, stay consistent, and expand over time.
+
+---
+
+## 🛠️ Make Onboarding Easy
+
+Help new members feel at home from day one:
+
+- Send a friendly welcome message
+- Create an **#introductions** channel
+- Provide a quickstart guide or community handbook
+- Share simple community rules
+
+The goal: help people understand how to participate and feel like they belong.
+
+---
+
+## 📅 Host Regular Events
+
+Events create energy and give members a reason to stay engaged. Some ideas:
+
+- **Community calls** (weekly, biweekly, or monthly)
+- **Live coding sessions**
+- **AMA (Ask Me Anything)** with the team or guests
+- **Hackathons or build challenges**
+- **Office hours** for product help or feedback
+
+Keep events consistent and relevant to your community’s interests.
+
+---
+
+## ✍️ Encourage Sharing and Collaboration
+
+Create a culture where members feel comfortable contributing:
+
+- Ask members to share what they’re building
+- Highlight cool projects or ideas
+- Invite tutorials, blog posts, or how-to guides
+- Make it easy to contribute to your documentation or repo
+
+You can also run content challenges, tutorials of the week, or spotlight series.
+
+---
+
+## 🌱 Show Appreciation
+
+Recognition builds loyalty. Simple gestures go a long way:
+
+- Public shoutouts to helpful members
+- Special roles, badges, or leaderboards
+- Swag or early access to new features
+- Member spotlights in newsletters or blog posts
+
+People stay when they feel valued.
+
+---
+
+## 📊 Track What Matters
+
+Use analytics and feedback to understand how your community is doing:
+
+- How many members are active
+- Which channels are most engaging
+- What content or questions come up often
+- What support or feedback keeps repeating
+
+Use this to improve your strategy and meet your community where they are.
+
+---
+
+Building and growing a developer community takes time, but with consistency, empathy, and clear purpose, you’ll create a space that people want to be a part ofe and stay in.


### PR DESCRIPTION
docs: add Community Building section with pages on Engagement, Events, and Knowledge Sharing

Added Pages:
community-building-and-engagement.md
→ Covers foundational practices for defining purpose, selecting channels, onboarding members, and driving engagement.
events-and-meetups.md
→ Outlines strategies for planning, running, and scaling virtual, in-person, and hybrid events to deepen community relationships.
content-and-knowledge-sharing.md -[Changed the retention page to this]
→ Offers methods to encourage user-generated content, tutorials, knowledge exchange, and community amplification.